### PR TITLE
feat: parse policies

### DIFF
--- a/src/nuc/policy.py
+++ b/src/nuc/policy.py
@@ -1,0 +1,273 @@
+"""
+NUC policy definitions.
+"""
+
+from dataclasses import dataclass
+from typing import Any, List
+
+from .selector import Selector
+
+
+@dataclass
+class EqualsOperator:
+    """
+    An operator that checks for equality.
+    """
+
+    arg: Any
+
+
+@dataclass
+class NotEqualsOperator:
+    """
+    An operator that checks for inequality.
+    """
+
+    arg: Any
+
+
+@dataclass
+class AnyOfOperator:
+    """
+    An operator that checks that a value is within a list of values.
+    """
+
+    arg: List[Any]
+
+
+@dataclass
+class OperatorPolicy:
+    """
+    A policy that applies a selector on the NUC token and applies an operator to it.
+    """
+
+    selector: Selector
+    operator: EqualsOperator | NotEqualsOperator | AnyOfOperator
+
+    @staticmethod
+    def parse(operator: str, data: Any) -> "OperatorPolicy":
+        """
+        Parse a policy.
+        """
+
+        keys = _ensure_list(data)
+        raw_selector = _pop_next(keys, "selector")
+        if not isinstance(raw_selector, str):
+            raise MalformedPolicyException("selector must be a string")
+        selector = Selector.parse(raw_selector)
+        value = _pop_next(keys, "value")
+        output = None
+        match operator:
+            case "==":
+                output = EqualsOperator(value)
+            case "!=":
+                output = NotEqualsOperator(value)
+            case "anyOf":
+                if not isinstance(value, list):
+                    raise MalformedPolicyException("'anyOf' expects list as value")
+                output = AnyOfOperator(value)
+            case _:
+                raise MalformedPolicyException(f"invalid operator '{operator}'")
+        return OperatorPolicy(selector, output)
+
+    def serialize(self) -> List[Any]:
+        """
+        Serialize this policy as a list.
+        """
+
+        selector = str(self.selector)
+        match self.operator:
+            case EqualsOperator(arg):
+                return ["==", selector, arg]
+            case NotEqualsOperator(arg):
+                return ["!=", selector, arg]
+            case AnyOfOperator(args):
+                return ["anyOf", selector, args]
+
+    def matches(self, value: Any) -> bool:
+        """
+        Checks whether this policy matches a value.
+        """
+
+        value = self.selector.apply(value)
+        match self.operator:
+            case EqualsOperator(arg):
+                return arg == value
+            case NotEqualsOperator(arg):
+                return arg != value
+            case AnyOfOperator(args):
+                return any(value == arg for arg in args)
+
+
+@dataclass
+class AndConnector:
+    """
+    A connector that checks that a sequence of policies is valid.
+    """
+
+    policies: List["Policy"]
+
+
+@dataclass
+class OrConnector:
+    """
+    A connector that checks that at least policy in a sequence is valid.
+    """
+
+    policies: List["Policy"]
+
+
+@dataclass
+class NotConnector:
+    """
+    A connector that checks that at a policy is not valid
+    """
+
+    policy: "Policy"
+
+
+type ConnectorPolicy = AndConnector | OrConnector | NotConnector
+
+
+@dataclass
+class Policy:
+    """
+    A policy that restricts how a NUC can be used.
+    """
+
+    body: OperatorPolicy | ConnectorPolicy
+
+    @staticmethod
+    def parse(data: Any) -> "Policy":
+        """
+        Parse a policy.
+        """
+
+        keys = _ensure_list(data)
+        op = _pop_next(keys, "operand")
+        body = None
+        match op:
+            case "==" | "!=" | "anyOf":
+                body = OperatorPolicy.parse(op, keys)
+            case "and":
+                body = AndConnector(_parse_policies(_pop_next(keys, "policies")))
+            case "or":
+                body = OrConnector(_parse_policies(_pop_next(keys, "policies")))
+            case "not":
+                body = NotConnector(Policy.parse(_pop_next(keys, "policy")))
+            case _:
+                raise MalformedPolicyException(f"invalid operator '{op}'")
+        return Policy(body)
+
+    def serialize(self) -> List[Any]:
+        """
+        Serialize this policy as a list.
+        """
+
+        match self.body:
+            case OperatorPolicy():
+                return self.body.serialize()
+            case AndConnector(policies):
+                return ["and", [policy.serialize() for policy in policies]]
+            case OrConnector(policies):
+                return ["or", [policy.serialize() for policy in policies]]
+            case NotConnector(policy):
+                return ["not", policy.serialize()]
+
+    def matches(self, value: Any) -> bool:
+        """
+        Checks whether this policy matches a value.
+        """
+
+        match self.body:
+            case OperatorPolicy():
+                return self.body.matches(value)
+            case AndConnector(policies):
+                return bool(policies) and all(
+                    policy.matches(value) for policy in policies
+                )
+            case OrConnector(policies):
+                return any(policy.matches(value) for policy in policies)
+            case NotConnector(policy):
+                return not policy.matches(value)
+
+    @staticmethod
+    def equals(selector: str, value: Any) -> "Policy":
+        """
+        Create a policy that expects a selected value to equal another.
+        """
+
+        return Policy(OperatorPolicy(Selector.parse(selector), EqualsOperator(value)))
+
+    @staticmethod
+    def not_equals(selector: str, value: Any) -> "Policy":
+        """
+        Create a policy that expects a selected value to be distinct from another.
+        """
+
+        return Policy(
+            OperatorPolicy(Selector.parse(selector), NotEqualsOperator(value))
+        )
+
+    @staticmethod
+    def any_of(selector: str, values: List[Any]) -> "Policy":
+        """
+        Create a policy that expects a selected value to match an element from a list.
+        """
+
+        return Policy(OperatorPolicy(Selector.parse(selector), AnyOfOperator(values)))
+
+    @staticmethod
+    def and_(policies: List["Policy"]) -> "Policy":
+        """
+        Create a policy that expects all sub-policies to be valid.
+        """
+
+        return Policy(AndConnector(policies))
+
+    @staticmethod
+    def or_(policies: List["Policy"]) -> "Policy":
+        """
+        Create a policy that expects at least one sub-policy to be valid.
+        """
+
+        return Policy(OrConnector(policies))
+
+    @staticmethod
+    def not_(policy: "Policy") -> "Policy":
+        """
+        Create a policy that expects a policy to be invalid.
+        """
+
+        return Policy(NotConnector(policy))
+
+
+def _ensure_list(data: Any) -> List[Any]:
+    if not isinstance(data, list):
+        raise MalformedPolicyException("expected list")
+    return data
+
+
+def _pop_next(keys: Any, expected: str) -> Any:
+    if not isinstance(keys, list):
+        raise MalformedPolicyException("policy must be a list")
+    if not keys:
+        raise MalformedPolicyException(f"invalid policy: expected {expected}")
+    return keys.pop(0)
+
+
+def _parse_policies(keys: Any) -> List[Policy]:
+    if not isinstance(keys, list):
+        raise MalformedPolicyException("expected a list of policies")
+    policies = []
+    for element in keys:
+        if not isinstance(element, list):
+            raise MalformedPolicyException("expected a policy list")
+        policies.append(Policy.parse(element))
+    return policies
+
+
+class MalformedPolicyException(Exception):
+    """
+    An exception that indicates a policy was malformed.
+    """

--- a/src/nuc/selector.py
+++ b/src/nuc/selector.py
@@ -1,0 +1,61 @@
+"""
+NUC selectors.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+_SELECTOR_REGEX: re.Pattern = re.compile("[a-zA-Z0-9_-]+")
+
+
+@dataclass
+class Selector:
+    """
+    A selector that specifies a path within a JSON object to be matched.
+    """
+
+    path: List[str]
+
+    @staticmethod
+    def parse(selector: str) -> "Selector":
+        """
+        Parse a selector from a string.
+        """
+
+        if not selector.startswith("."):
+            raise MalformedSelectorException("selectors must start with '.'")
+
+        selector = selector[1:]
+        if not selector:
+            return Selector([])
+
+        labels = []
+        for label in selector.split("."):
+            if not label:
+                raise MalformedSelectorException("selector segment can't be empty")
+            if not _SELECTOR_REGEX.match(label):
+                raise MalformedSelectorException("invalid characters found in selector")
+            labels.append(label)
+        return Selector(labels)
+
+    def apply(self, value: Dict[str, Any]) -> Any:
+        """
+        Apply a selector on a value and return the matched value, if any.
+        """
+
+        output = value
+        for label in self.path:
+            output = output.get(label)
+            if not output:
+                return None
+        return output
+
+    def __str__(self) -> str:
+        return "." + ".".join(self.path)
+
+
+class MalformedSelectorException(Exception):
+    """
+    An exception that indicates a selector is malformed.
+    """

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -1,0 +1,131 @@
+from copy import deepcopy
+import pytest
+from typing import Any, List
+
+from nuc.policy import MalformedPolicyException, Policy
+
+
+class TestPolicy:
+    @pytest.mark.parametrize(
+        "input,expected",
+        [
+            (["==", ".foo", {"bar": 42}], Policy.equals(".foo", {"bar": 42})),
+            (["!=", ".foo", {"bar": 42}], Policy.not_equals(".foo", {"bar": 42})),
+            (["anyOf", ".foo", [42, "hi"]], Policy.any_of(".foo", [42, "hi"])),
+            (["anyOf", ".foo", [{"foo": 42}]], Policy.any_of(".foo", [{"foo": 42}])),
+            (
+                ["and", [["==", ".foo", 42], ["!=", ".bar", False]]],
+                Policy.and_(
+                    [Policy.equals(".foo", 42), Policy.not_equals(".bar", False)]
+                ),
+            ),
+            (
+                ["or", [["==", ".foo", 42], ["!=", ".bar", False]]],
+                Policy.or_(
+                    [Policy.equals(".foo", 42), Policy.not_equals(".bar", False)]
+                ),
+            ),
+            (
+                ["not", ["==", ".foo", 42]],
+                Policy.not_(Policy.equals(".foo", 42)),
+            ),
+            (
+                [
+                    "or",
+                    [
+                        ["==", ".foo", 42],
+                        ["and", [["!=", ".bar", 1337], ["not", ["==", ".tar", True]]]],
+                    ],
+                ],
+                Policy.or_(
+                    [
+                        Policy.equals(".foo", 42),
+                        Policy.and_(
+                            [
+                                Policy.not_equals(".bar", 1337),
+                                Policy.not_(Policy.equals(".tar", True)),
+                            ]
+                        ),
+                    ]
+                ),
+            ),
+        ],
+    )
+    def test_parse_valid(self, input: List[Any], expected: Policy):
+        parsed = Policy.parse(deepcopy(input))
+        assert parsed == expected
+
+        # Also ensure we can go back to the original input
+        assert parsed.serialize() == input
+
+    @pytest.mark.parametrize(
+        "input",
+        [
+            [],
+            ["=="],
+            ["hi", ".foo", []],
+            ["==", ".foo"],
+            ["!=", ".foo"],
+            ["anyOf", ".foo"],
+            ["anyOf", ".foo", 42],
+            ["and"],
+            ["or"],
+            ["not"],
+            ["and", 42],
+            ["and", [42]],
+            ["and", ["hi"]],
+            ["and", [["hi"]]],
+            ["and", [[42]]],
+            ["not", "hi"],
+            ["not", 42],
+        ],
+    )
+    def test_parse_invalid(self, input: List[Any]):
+        with pytest.raises(MalformedPolicyException):
+            Policy.parse(input)
+
+    @pytest.mark.parametrize(
+        "policy",
+        [
+            Policy.equals(".name.first", "bob"),
+            Policy.not_equals(".name.first", "john"),
+            Policy.equals(".name", {"first": "bob", "last": "smith"}),
+            Policy.equals(".", {"name": {"first": "bob", "last": "smith"}, "age": 42}),
+            Policy.not_equals(".age", 150),
+            Policy.any_of(".name.first", ["john", "bob"]),
+            Policy.and_(
+                [Policy.equals(".age", 42), Policy.equals(".name.first", "bob")]
+            ),
+            Policy.or_([Policy.equals(".age", 42), Policy.equals(".age", 150)]),
+            Policy.or_([Policy.equals(".age", 150), Policy.equals(".age", 42)]),
+        ],
+    )
+    def test_evaluation_matches(self, policy: Policy):
+        value = {"name": {"first": "bob", "last": "smith"}, "age": 42}
+        assert policy.matches(value)
+
+    @pytest.mark.parametrize(
+        "policy",
+        [
+            Policy.equals(".name.first", "john"),
+            Policy.not_equals(".name.first", "bob"),
+            Policy.equals(".name", {"first": "john", "last": "smith"}),
+            Policy.equals(
+                ".", {"name": {"first": "john", "last": "smith"}, "age": 100}
+            ),
+            Policy.not_(Policy.equals(".age", 42)),
+            Policy.any_of(".name.first", ["john", "jack"]),
+            Policy.and_(
+                [Policy.equals(".age", 150), Policy.equals(".name.first", "bob")]
+            ),
+            Policy.and_(
+                [Policy.equals(".age", 42), Policy.equals(".name.first", "john")]
+            ),
+            Policy.and_([]),
+            Policy.or_([]),
+            Policy.or_([Policy.equals(".age", 101), Policy.equals(".age", 100)]),
+        ],
+    )
+    def test_evaluation_does_not_match(self, policy: Policy):
+        value = {"name": {"first": "bob", "last": "smith"}, "age": 42}
+        assert not policy.matches(value)

--- a/test/test_selector.py
+++ b/test/test_selector.py
@@ -1,0 +1,42 @@
+import pytest
+from typing import Any, Dict, List
+from nuc.selector import MalformedSelectorException, Selector
+
+
+class TestSelector:
+    @pytest.mark.parametrize(
+        "input,expected",
+        [
+            (".", []),
+            (".foo", ["foo"]),
+            (".foo.bar", ["foo", "bar"]),
+            (
+                ".abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_",
+                ["abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"],
+            ),
+        ],
+    )
+    def test_parse_valid(self, input: str, expected: List[str]):
+        selector = Selector.parse(input)
+        assert selector.path == expected
+
+    @pytest.mark.parametrize(
+        "input",
+        ["", "A", ".#", ".🚀", ".A.", ".A..B"],
+    )
+    def test_parse_invalid(self, input: str):
+        with pytest.raises(MalformedSelectorException):
+            Selector.parse(input)
+
+    @pytest.mark.parametrize(
+        "expression,input,expected",
+        [
+            (".", {"foo": 42}, {"foo": 42}),
+            (".foo", {"foo": 42}, 42),
+            (".foo.bar", {"foo": {"bar": 42}}, 42),
+            (".foo", {"bar": 42}, None),
+        ],
+    )
+    def test_lookup(self, expression: str, input: Dict[str, Any], expected: Any):
+        selector = Selector.parse(expression)
+        assert selector.apply(input) == expected


### PR DESCRIPTION
This adds the necessary code to be able to parse/serialize/evaluate policies. Test cases were copied over from the rust implementation to keep them aligned. Docs here aren't covering parameters for brevity; I think it will be nice to do a pass at the end to document whatever is missing so we can have something functional before we spend time cleaning things up.