### PR TITLE
feat: add NUC token builder

### DIFF
--- a/src/nuc/builder.py
+++ b/src/nuc/builder.py
@@ -1,0 +1,197 @@
+"""
+NUC builder.
+"""
+
+import secrets
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict
+
+from secp256k1 import PrivateKey
+
+from nuc.envelope import NucTokenEnvelope, urlsafe_base64_encode
+from nuc.token import Command, DelegationBody, Did, InvocationBody, NucToken
+
+_DEFAULT_NONCE_LENGTH: int = 16
+
+
+@dataclass()
+class NucTokenBuilder:
+    """
+    A builder for a NUC token.
+    """
+
+    # pylint: disable=R0902
+    def __init__(
+        self,
+        body: InvocationBody | DelegationBody,
+        audience: Did | None = None,
+        subject: Did | None = None,
+        not_before: datetime | None = None,
+        expires_at: datetime | None = None,
+        command: Command | None = None,
+        meta: Dict[str, Any] | None = None,
+        nonce: bytes | None = None,
+        proof: NucTokenEnvelope | None = None,
+    ) -> None:
+        self._body = body
+        self._audience = audience
+        self._subject = subject
+        self._not_before = not_before
+        self._expires_at = expires_at
+        self._command = command
+        self._meta = meta
+        self._nonce = nonce
+        self._proof = proof
+
+    @staticmethod
+    def delegation(body: DelegationBody) -> "NucTokenBuilder":
+        """
+        Create a new token builder for a delegation.
+        """
+
+        return NucTokenBuilder(body=body)
+
+    @staticmethod
+    def invocation(body: InvocationBody) -> "NucTokenBuilder":
+        """
+        Create a new token builder for an invocation.
+        """
+
+        return NucTokenBuilder(body=body)
+
+    @staticmethod
+    def extending(envelope: NucTokenEnvelope) -> "NucTokenBuilder":
+        """
+        Create a token that pulls basic properties from another one.
+        """
+
+        token = envelope.token.token
+        if isinstance(token.body, InvocationBody):
+            raise TokenBuildException("cannot extend an invocation")
+        return NucTokenBuilder(
+            body=token.body,
+            proof=envelope,
+            command=token.command,
+            subject=token.subject,
+        )
+
+    def audience(self, audience: Did) -> "NucTokenBuilder":
+        """
+        Set the audience for the token to be built.
+        """
+
+        self._audience = audience
+        return self
+
+    def subject(self, subject: Did) -> "NucTokenBuilder":
+        """
+        Set the subject for the token to be built.
+        """
+
+        self._subject = subject
+        return self
+
+    def not_before(self, not_before: datetime) -> "NucTokenBuilder":
+        """
+        Set the `not before` date for the token to be built.
+        """
+
+        self._not_before = not_before
+        return self
+
+    def expires_at(self, expires_at: datetime) -> "NucTokenBuilder":
+        """
+        Set the `expires at` date for the token to be built.
+        """
+
+        self._expires_at = expires_at
+        return self
+
+    def command(self, command: Command) -> "NucTokenBuilder":
+        """
+        Set the command for the token to be built.
+        """
+
+        self._command = command
+        return self
+
+    def meta(self, meta: Dict[str, Any]) -> "NucTokenBuilder":
+        """
+        Set the metadata for the token to be built.
+        """
+
+        self._meta = meta
+        return self
+
+    def nonce(self, nonce: bytes) -> "NucTokenBuilder":
+        """
+        Set the nonce for the token to be built.
+        """
+
+        self._nonce = nonce
+        return self
+
+    def proof(self, proof: NucTokenEnvelope) -> "NucTokenBuilder":
+        """
+        Set the proof for the token to be built.
+        """
+
+        self._proof = proof
+        return self
+
+    def build(self, key: PrivateKey) -> str:
+        """
+        Build the token, signing it using the given private key.
+        """
+
+        body = self._body
+        issuer = Did(key.pubkey.serialize())  # type: ignore
+        audience = self._get(self._audience, "audience")
+        subject = self._get(self._subject, "subject")
+        not_before = self._not_before
+        expires_at = self._expires_at
+        command = self._get(self._command, "command")
+        meta = self._meta
+        nonce = (
+            self._nonce if self._nonce else secrets.token_bytes(_DEFAULT_NONCE_LENGTH)
+        )
+        proof = self._proof
+        if proof:
+            proof.validate_signatures()
+        proof_hashes = [proof.token.compute_hash()] if proof else []
+        token = NucToken(
+            issuer,
+            audience,
+            subject,
+            not_before,
+            expires_at,
+            command,
+            body,
+            meta,
+            nonce,
+            proof_hashes,
+        )
+        token = str(token).encode("utf8")
+        header = '{"alg":"ES256K"}'.encode("utf8")
+        token = f"{urlsafe_base64_encode(header)}.{urlsafe_base64_encode(token)}"
+        signature = key.ecdsa_serialize_compact(key.ecdsa_sign(token.encode("utf8")))
+        token = f"{token}.{urlsafe_base64_encode(signature)}"
+        if self._proof:
+            all_proofs = [self._proof.token] + self._proof.proofs
+            proofs = "/".join([str(proof) for proof in all_proofs])
+            token = f"{token}/{proofs}"
+        return token
+
+    def _get[T](self, field: T | None, name: str) -> T:
+        match field:
+            case None:
+                raise TokenBuildException(f"field {name} not set")
+            case _:
+                return field
+
+
+class TokenBuildException(Exception):
+    """
+    An exception raised when building a token.
+    """

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -1,0 +1,125 @@
+from datetime import UTC, datetime
+import json
+
+from secp256k1 import PrivateKey
+from nuc.builder import NucTokenBuilder
+from nuc.envelope import NucTokenEnvelope, urlsafe_base64_decode
+from nuc.policy import Policy
+from nuc.token import Command, DelegationBody, Did, InvocationBody, NucToken
+
+
+class TestNucTokenBuilder:
+    def test_extend(self):
+        key = PrivateKey()
+        base = (
+            NucTokenBuilder.delegation(DelegationBody([Policy.equals(".foo", 42)]))
+            .audience(Did(bytes([0xBB] * 33)))
+            .subject(Did(bytes([0xCC] * 33)))
+            .command(Command(["nil", "db", "read"]))
+            .build(key)
+        )
+        base = NucTokenEnvelope.parse(base)
+
+        ext = (
+            NucTokenBuilder.extending(base).audience(Did(bytes([0xDD] * 33))).build(key)
+        )
+        ext = NucTokenEnvelope.parse(ext)
+
+        assert ext.token.token.command == base.token.token.command
+        assert ext.token.token.subject == base.token.token.subject
+
+        proofs = ext.proofs
+        assert len(proofs) == 1
+        assert proofs[0] == base.token
+
+    def test_encode_decode(self):
+        key = PrivateKey()
+        token = (
+            NucTokenBuilder.delegation(DelegationBody([]))
+            .audience(Did(bytes([0xBB] * 33)))
+            .subject(Did(bytes([0xCC] * 33)))
+            .command(Command(["nil", "db", "read"]))
+            .not_before(datetime.fromtimestamp(1740494955, tz=UTC))
+            .expires_at(datetime.fromtimestamp(1740495955, tz=UTC))
+            .nonce(bytes([1, 2, 3]))
+            .meta({"name": "bob"})
+            .build(key)
+        )
+        envelope = NucTokenEnvelope.parse(token)
+        envelope.validate_signatures()
+
+        [header, _] = token.split(".", 1)
+        assert json.loads(urlsafe_base64_decode(header)) == json.loads(
+            '{"alg": "ES256K"}'
+        )
+
+        expected_token = NucToken(
+            issuer=Did(key.pubkey.serialize()),  # type: ignore
+            audience=Did(bytes([0xBB] * 33)),
+            subject=Did(bytes([0xCC] * 33)),
+            command=Command(["nil", "db", "read"]),
+            not_before=datetime.fromtimestamp(1740494955, tz=UTC),
+            expires_at=datetime.fromtimestamp(1740495955, tz=UTC),
+            nonce=bytes([1, 2, 3]),
+            meta={"name": "bob"},
+            body=DelegationBody([]),
+            proofs=[],
+        )
+        assert envelope.token.token == expected_token
+
+    def test_chain(self):
+        # Build a root NUC
+        root_key = PrivateKey()
+        root = (
+            NucTokenBuilder.delegation(DelegationBody([Policy.equals(".foo", 42)]))
+            .audience(Did(bytes([0xBB] * 33)))
+            .subject(Did(bytes([0xCC] * 33)))
+            .command(Command(["nil", "db", "read"]))
+            .build(root_key)
+        )
+        root = NucTokenEnvelope.parse(root)
+        root.validate_signatures()
+
+        # Build a delegation using the above proof
+        other_key = PrivateKey()
+        delegation = (
+            NucTokenBuilder.delegation(DelegationBody([Policy.equals(".foo", 42)]))
+            .audience(Did(bytes([0xBB] * 33)))
+            .subject(Did(bytes([0xCC] * 33)))
+            .command(Command(["nil", "db", "read"]))
+            .proof(root)
+            .build(other_key)
+        )
+        delegation = NucTokenEnvelope.parse(delegation)
+        delegation.validate_signatures()
+
+        # Ensure the tokens are linked
+        assert delegation.token.token.proofs == [root.token.compute_hash()]
+        assert len(delegation.proofs) == 1
+        assert delegation.proofs[0] == root.token
+
+        # Build an invocation using the above proof
+        yet_another_key = PrivateKey()
+        invocation = (
+            NucTokenBuilder.invocation(InvocationBody({"beep": 42}))
+            .audience(Did(bytes([0xBB] * 33)))
+            .subject(Did(bytes([0xCC] * 33)))
+            .command(Command(["nil", "db", "read"]))
+            .proof(delegation)
+            .build(yet_another_key)
+        )
+        invocation = NucTokenEnvelope.parse(invocation)
+        invocation.validate_signatures()
+
+        # Ensure both delegations are included as proof
+        assert invocation.token.token.proofs == [delegation.token.compute_hash()]
+        proofs = invocation.proofs
+        assert len(proofs) == 2
+        assert proofs[0] == delegation.token
+        assert proofs[1] == root.token
+
+    def decode_specific(self):
+        token = "eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAyMjZhNGQ0YTRhNWZhZGUxMmM1ZmYwZWM5YzQ3MjQ5ZjIxY2Y3N2EyMDI3NTFmOTU5ZDVjNzc4ZjBiNjUyYjcxNiIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJhcmdzIjp7ImZvbyI6NDJ9LCJub25jZSI6IjAxMDIwMyIsInByZiI6WyJjOTA0YzVhMWFiMzY5YWVhMWI0ZDlkMTkwMmE0NmU2ZWY5NGFhYjk2OTY0YmI1MWQ2MWE2MWIwM2UyM2Q1ZGZmIl19.ufDYxqoSVNVETrVKReu0h_Piul5c6RoC_VnGGLw04mkyn2OMrtQjK92sGXNHCjlp7T9prIwxX14ZB_N3gx7hPg/eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAzNmY3MDdmYmVmMGI3NTIxMzgwOGJiYmY1NGIxODIxNzZmNTMyMGZhNTIwY2I4MTlmMzViNWJhZjIzMjM4YTAxNSIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJwb2wiOltbIj09IiwiLmZvbyIsNDJdXSwibm9uY2UiOiIwMTAyMDMiLCJwcmYiOlsiODZjZGI1ZjZjN2M3NDFkMDBmNmI4ODMzZDI0ZjdlY2Y5MWFjOGViYzI2MzA3MmZkYmU0YTZkOTQ5NzIwMmNiNCJdfQ.drGzkA0hYP8h62GxNN3fhi9bKjYgjpSy4cM52-9RsyB7JD6O6K1wRsg_x1hv8ladPmChpwDVVXOzjNr2NRVntA/eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAzOTU5MGNjYWYxMDI0ZjQ5YzljZjc0M2Y4YTZlZDQyMDNlNzgyZThlZTA5YWZhNTNkMWI1NzY0OTg0NjEyMzQyNSIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJwb2wiOltbIj09IiwiLmZvbyIsNDJdXSwibm9uY2UiOiIwMTAyMDMiLCJwcmYiOltdfQ.o3lnQxCjDCW10UuRABrHp8FpB_C6q1xgEGvfuXTb7Epp63ry8R2h0wHjToDKDFmkmUmO2jcBkrttuy8kftV6og"
+
+        # this is a token generated by the above function
+        NucTokenEnvelope.parse(token).validate_signatures()


### PR DESCRIPTION
This adds a builder for NUC tokens that performs signatures and creates proof chains. Tests again were ported over from the rust impl.