### PR TITLE
feat: add code to interact with authority service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = {text = "MIT"}
 readme = "README.rst"
 requires-python = ">=3.9"
 dependencies = [
+    "requests==2.32.3",
     "secp256k1==0.14.0",
 ]
 

--- a/src/nuc/authority.py
+++ b/src/nuc/authority.py
@@ -1,0 +1,69 @@
+"""
+Authority service APIs.
+"""
+
+from dataclasses import dataclass
+import secrets
+import json
+import requests
+from secp256k1 import PrivateKey
+
+from nuc.envelope import NucTokenEnvelope
+
+
+DEFAULT_REQUEST_TIMEOUT: float = 10
+
+
+@dataclass()
+class AuthorityServiceAbout:
+    """
+    Information about the authority service.
+    """
+
+    public_key: bytes
+
+
+class AuthorityService:
+    """
+    A class to interact with the authority service.
+    """
+
+    def __init__(self, base_url: str, timeout_seconds=DEFAULT_REQUEST_TIMEOUT) -> None:
+        self._base_url = base_url
+        self._timeout_seconds = timeout_seconds
+
+    def request_token(self, key: PrivateKey) -> NucTokenEnvelope:
+        """
+        Request a token, issued to the public key tied to the given private key.
+        """
+
+        payload = json.dumps(
+            {
+                "nonce": list(secrets.token_bytes(16)),
+            }
+        ).encode("utf8")
+        signature = key.ecdsa_serialize_compact(key.ecdsa_sign(payload))
+        request = {
+            "public_key": key.pubkey.serialize().hex(),  # type: ignore
+            "signature": signature.hex(),
+            "payload": payload.hex(),
+        }
+        response = requests.post(
+            f"{self._base_url}/api/v1/nucs/create",
+            json=request,
+            timeout=self._timeout_seconds,
+        )
+        response.raise_for_status()
+        response = response.json()
+        return NucTokenEnvelope.parse(response["token"])
+
+    def about(self) -> AuthorityServiceAbout:
+        """
+        Get information about the authority service.
+        """
+        response = requests.get(
+            f"{self._base_url}/about", timeout=self._timeout_seconds
+        )
+        response.raise_for_status()
+        about = response.json()
+        return AuthorityServiceAbout(public_key=bytes.fromhex(about["public_key"]))

--- a/test/test_authority.py
+++ b/test/test_authority.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+from secp256k1 import PrivateKey, PublicKey
+
+from nuc.builder import NucTokenBuilder
+from nuc.authority import AuthorityService
+from nuc.envelope import NucTokenEnvelope
+from nuc.policy import Policy
+from nuc.token import Command, DelegationBody, Did
+
+
+class TestAuthorityService:
+    @patch("requests.post")
+    def test_request_token(self, mock_post):
+        base_url = "http://127.0.0.1"
+        service = AuthorityService(base_url)
+        root_key = PrivateKey()
+
+        response_token = (
+            NucTokenBuilder.delegation(DelegationBody([Policy.equals(".foo", 42)]))
+            .audience(Did(bytes([0xBB] * 33)))
+            .subject(Did(bytes([0xCC] * 33)))
+            .command(Command(["nil", "db", "read"]))
+            .build(root_key)
+        )
+        mock_post.return_value.json.return_value = {"token": response_token}
+
+        key = PrivateKey()
+        envelope = service.request_token(key)
+        assert envelope.token == NucTokenEnvelope.parse(response_token).token
+
+        invocation = mock_post.call_args_list[0]
+        assert invocation.args == (f"{base_url}/api/v1/nucs/create",)
+
+        pub_key: PublicKey = key.pubkey  # type: ignore
+        params = invocation.kwargs.pop("json")
+        assert params["public_key"] == pub_key.serialize().hex()
+        assert pub_key.ecdsa_verify(
+            bytes.fromhex(params["payload"]),
+            key.ecdsa_deserialize_compact(bytes.fromhex(params["signature"])),
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -656,6 +656,7 @@ name = "nuc"
 version = "0.0.0a0"
 source = { editable = "." }
 dependencies = [
+    { name = "requests" },
     { name = "secp256k1" },
 ]
 
@@ -690,6 +691,7 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'lint'", specifier = "==1.1.396" },
     { name = "pytest", marker = "extra == 'test'", specifier = "~=8.2" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = "~=5.0" },
+    { name = "requests", specifier = "==2.32.3" },
     { name = "ruff", marker = "extra == 'lint'", specifier = "==0.7.0" },
     { name = "secp256k1", specifier = "==0.14.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = "~=5.0" },


### PR DESCRIPTION
This adds an `AuthorityService` class that allows getting tokens from the authority service.

Example use

```python
    key = PrivateKey()
    service = AuthorityService("http://localhost:30921")

    service_key = service.about().public_key
    envelope = service.request_token(key)
    envelope.validate_signatures()

    assert envelope.token.token.issuer.public_key == service_key
```