### PR TITLE
chore: return raw token when fetching it from service

### DIFF
--- a/src/nuc/authority.py
+++ b/src/nuc/authority.py
@@ -8,8 +8,6 @@ import json
 import requests
 from secp256k1 import PrivateKey
 
-from nuc.envelope import NucTokenEnvelope
-
 
 DEFAULT_REQUEST_TIMEOUT: float = 10
 
@@ -32,7 +30,7 @@ class AuthorityService:
         self._base_url = base_url
         self._timeout_seconds = timeout_seconds
 
-    def request_token(self, key: PrivateKey) -> NucTokenEnvelope:
+    def request_token(self, key: PrivateKey) -> str:
         """
         Request a token, issued to the public key tied to the given private key.
         """
@@ -55,7 +53,7 @@ class AuthorityService:
         )
         response.raise_for_status()
         response = response.json()
-        return NucTokenEnvelope.parse(response["token"])
+        return response["token"]
 
     def about(self) -> AuthorityServiceAbout:
         """

--- a/test/test_authority.py
+++ b/test/test_authority.py
@@ -3,7 +3,6 @@ from secp256k1 import PrivateKey, PublicKey
 
 from nuc.builder import NucTokenBuilder
 from nuc.authority import AuthorityService
-from nuc.envelope import NucTokenEnvelope
 from nuc.policy import Policy
 from nuc.token import Command, DelegationBody, Did
 
@@ -25,8 +24,8 @@ class TestAuthorityService:
         mock_post.return_value.json.return_value = {"token": response_token}
 
         key = PrivateKey()
-        envelope = service.request_token(key)
-        assert envelope.token == NucTokenEnvelope.parse(response_token).token
+        token = service.request_token(key)
+        assert token == response_token
 
         invocation = mock_post.call_args_list[0]
         assert invocation.args == (f"{base_url}/api/v1/nucs/create",)


### PR DESCRIPTION
Returning a `NucTokenEnvelope` limits what you can do so this makes the call to the authority service return the raw token instead.