### PR TITLE
feat: send target public key and expiration time in request

### DIFF
--- a/src/nuc/authority.py
+++ b/src/nuc/authority.py
@@ -2,6 +2,7 @@
 Authority service APIs.
 """
 
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 import secrets
 import json
@@ -76,9 +77,14 @@ class AuthorityServiceClient:
             never transmitted anywhere.
         """
 
+        public_key = self.about().public_key
+
+        expires_at = datetime.now(timezone.utc) + timedelta(minutes=1)
         payload = json.dumps(
             {
                 "nonce": secrets.token_bytes(16).hex(),
+                "target_public_key": public_key.serialize().hex(),
+                "expires_at": int(expires_at.timestamp()),
             }
         ).encode("utf8")
         signature = key.ecdsa_serialize_compact(key.ecdsa_sign(payload))

--- a/test/test_authority.py
+++ b/test/test_authority.py
@@ -9,10 +9,16 @@ from nuc.token import Command, Did
 
 class TestAuthorityService:
     @patch("requests.post")
-    def test_request_token(self, mock_post):
+    @patch("requests.get")
+    def test_request_token(self, mock_get, mock_post):
         base_url = "http://127.0.0.1"
         service = AuthorityServiceClient(base_url)
         root_key = PrivateKey()
+
+        # Pretend like we get back a public key
+        mock_get.return_value.json.return_value = {
+            "public_key": PrivateKey().pubkey.serialize().hex()  # type: ignore
+        }
 
         response_token = (
             NucTokenBuilder.delegation([Policy.equals(".foo", 42)])


### PR DESCRIPTION
This implements the client side logic defined in https://github.com/NillionNetwork/authority-service/pull/8