### PR TITLE
fix: require root proofs even when no proofs are provided

### DIFF
--- a/src/nuc/validate.py
+++ b/src/nuc/validate.py
@@ -151,6 +151,8 @@ class NucTokenValidator:
 
     def _validate_proofs(self, proofs: List[NucToken]) -> None:
         if not proofs:
+            if self._root_issuers:
+                raise ValidationException(ValidationKind.ROOT_KEY_SIGNATURE_MISSING)
             return
 
         if proofs[-1].issuer not in self._root_issuers:

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -61,12 +61,13 @@ class Asserter:
         self, parameters: ValidationParameters = ValidationParameters.default()
     ) -> None:
         self._parameters = parameters
+        self._root_dids = ROOT_DIDS
 
     def assert_failure(
         self, envelope: NucTokenEnvelope, expected_failure: ValidationKind
     ) -> None:
         self._log_tokens(envelope)
-        validator = NucTokenValidator(ROOT_DIDS)
+        validator = NucTokenValidator(self._root_dids)
         try:
             validator.validate(envelope, self._parameters)
             raise Exception("validation did not fail")
@@ -75,7 +76,7 @@ class Asserter:
 
     def assert_success(self, envelope: NucTokenEnvelope):
         self._log_tokens(envelope)
-        validator = NucTokenValidator(ROOT_DIDS)
+        validator = NucTokenValidator(self._root_dids)
         validator.validate(envelope, self._parameters)
 
     @staticmethod
@@ -276,7 +277,9 @@ class TestTokenValidator:
         envelope = f"{header}.{payload}.{urlsafe_base64_encode(bytes(signature))}"
         envelope = NucTokenEnvelope.parse(envelope)
 
-        Asserter().assert_failure(envelope, ValidationKind.INVALID_SIGNATURES)
+        asserter = Asserter()
+        asserter._root_dids = []
+        asserter.assert_failure(envelope, ValidationKind.INVALID_SIGNATURES)
 
     def test_missing_proof(self):
         key = PrivateKey()


### PR DESCRIPTION
Port of https://github.com/NillionNetwork/nuc-ts/pull/35