### PR TITLE
fix: root NUC validation

### DIFF
--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -560,3 +560,26 @@ class TestTokenValidator:
         parameters = ValidationParameters.default()
         parameters.token_requirements = InvocationRequirement(rpc_did)
         Asserter(parameters).assert_success(envelope)
+
+    def test_root_token(self):
+        subject_key = PrivateKey()
+        root = delegation(subject_key).command(Command(["nil"]))
+        envelope = Chainer().chain(
+            [
+                SignableNucTokenBuilder.issued_by_root(root),
+            ]
+        )
+        parameters = ValidationParameters.default()
+        Asserter(parameters).assert_success(envelope)
+
+    def test_no_root_keys(self):
+        subject_key = PrivateKey()
+        root = delegation(subject_key).command(Command(["nil"]))
+        envelope = Chainer().chain(
+            [
+                SignableNucTokenBuilder(subject_key, root),
+            ]
+        )
+        asserter = Asserter()
+        asserter._root_dids = []
+        asserter.assert_success(envelope)


### PR DESCRIPTION
The recent change on NUC validation when there were root keys in the validator but there were no proofs in the token caused tokens minted by nilauth to be considered invalid. This changes that so that if there are no proofs and there are root keys, we consider the token valid if the token itself is signed by a root keypair.

Same fix as https://github.com/NillionNetwork/nilvm/pull/99