### PR TITLE
feat: add NUC context support in selectors

### DIFF
--- a/src/nuc/selector.py
+++ b/src/nuc/selector.py
@@ -104,7 +104,7 @@ class Selector:
                     return None
                 first = self.path[0]
                 context_value = context.get(first)
-                if not context_value:
+                if context_value is None:
                     return None
                 return self._apply_on_value(self.path[1:], context_value)
 

--- a/src/nuc/selector.py
+++ b/src/nuc/selector.py
@@ -2,11 +2,33 @@
 NUC selectors.
 """
 
+from enum import Enum
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
 _SELECTOR_REGEX: re.Pattern = re.compile("[a-zA-Z0-9_-]+")
+
+type SelectorContext = Dict[str, Dict[str, Any]]
+"""
+The context for a selector: a key value pair where values are arbitrary dicts.
+"""
+
+
+class SelectorTarget(Enum):
+    """
+    The target for a selector.
+    """
+
+    TOKEN = 0
+    """
+    The target is the token itself.
+    """
+
+    CONTEXT = 1
+    """
+    The target is the provided context.
+    """
 
 
 @dataclass
@@ -16,6 +38,7 @@ class Selector:
     """
 
     path: List[str]
+    target: SelectorTarget
 
     @staticmethod
     def parse(selector: str) -> "Selector":
@@ -38,12 +61,21 @@ class Selector:
             selector = Selector.parse(".foo.bar")
         """
 
+        target = SelectorTarget.TOKEN
+        if selector.startswith("$"):
+            target = SelectorTarget.CONTEXT
+            selector = selector[1:]
+
         if not selector.startswith("."):
-            raise MalformedSelectorException("selectors must start with '.'")
+            raise MalformedSelectorException("selectors must start with '.' or '$.'")
 
         selector = selector[1:]
         if not selector:
-            return Selector([])
+            match target:
+                case SelectorTarget.TOKEN:
+                    return Selector([], target)
+                case SelectorTarget.CONTEXT:
+                    raise MalformedSelectorException("context selector needs path")
 
         labels = []
         for label in selector.split("."):
@@ -52,9 +84,9 @@ class Selector:
             if not _SELECTOR_REGEX.match(label):
                 raise MalformedSelectorException("invalid characters found in selector")
             labels.append(label)
-        return Selector(labels)
+        return Selector(labels, target)
 
-    def apply(self, value: Dict[str, Any]) -> Any:
+    def apply(self, value: Dict[str, Any], context: SelectorContext) -> Any:
         """
         Apply a selector on a value and return the matched value, if any.
 
@@ -64,16 +96,34 @@ class Selector:
         value
             The dict that this selector should be applied to.
         """
+        match self.target:
+            case SelectorTarget.TOKEN:
+                return self._apply_on_value(self.path, value)
+            case SelectorTarget.CONTEXT:
+                if not self.path:
+                    return None
+                first = self.path[0]
+                context_value = context.get(first)
+                if not context_value:
+                    return None
+                return self._apply_on_value(self.path[1:], context_value)
 
+    @staticmethod
+    def _apply_on_value(path: List[str], value: Dict[str, Any]) -> Any:
         output = value
-        for label in self.path:
+        for label in path:
             output = output.get(label)
             if not output:
                 return None
         return output
 
     def __str__(self) -> str:
-        return "." + ".".join(self.path)
+        match self.target:
+            case SelectorTarget.TOKEN:
+                prefix = ""
+            case SelectorTarget.CONTEXT:
+                prefix = "$"
+        return f"{prefix}.{'.'.join(self.path)}"
 
 
 class MalformedSelectorException(Exception):

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -90,6 +90,8 @@ class TestPolicy:
             Policy.equals(".name.first", "bob"),
             Policy.not_equals(".name.first", "john"),
             Policy.equals(".name", {"first": "bob", "last": "smith"}),
+            Policy.equals("$.req.foo", 42),
+            Policy.equals("$.other", 1337),
             Policy.equals(".", {"name": {"first": "bob", "last": "smith"}, "age": 42}),
             Policy.not_equals(".age", 150),
             Policy.any_of(".name.first", ["john", "bob"]),
@@ -102,7 +104,8 @@ class TestPolicy:
     )
     def test_evaluation_matches(self, policy: Policy):
         value = {"name": {"first": "bob", "last": "smith"}, "age": 42}
-        assert policy.matches(value)
+        context = {"req": {"foo": 42, "bar": "zar"}, "other": 1337}
+        assert policy.matches(value, context)
 
     @pytest.mark.parametrize(
         "policy",
@@ -110,6 +113,8 @@ class TestPolicy:
             Policy.equals(".name.first", "john"),
             Policy.not_equals(".name.first", "bob"),
             Policy.equals(".name", {"first": "john", "last": "smith"}),
+            Policy.equals("$.req.foo", 43),
+            Policy.not_equals("$.other", 1337),
             Policy.equals(
                 ".", {"name": {"first": "john", "last": "smith"}, "age": 100}
             ),
@@ -128,4 +133,5 @@ class TestPolicy:
     )
     def test_evaluation_does_not_match(self, policy: Policy):
         value = {"name": {"first": "bob", "last": "smith"}, "age": 42}
-        assert not policy.matches(value)
+        context = {"req": {"foo": 42, "bar": "zar"}, "other": 1337}
+        assert not policy.matches(value, context)

--- a/test/test_selector.py
+++ b/test/test_selector.py
@@ -54,9 +54,10 @@ class TestSelector:
             ("$.req.foo", 42),
             ("$.foo", None),
             ("$.req.choochoo", None),
+            ("$.bool", False),
         ],
     )
     def test_lookup_context(self, expression: str, expected: Any):
         selector = Selector.parse(expression)
-        context = {"req": {"foo": 42, "bar": "zar"}, "other": 1337}
+        context = {"req": {"foo": 42, "bar": "zar"}, "other": 1337, "bool": False}
         assert selector.apply({}, context) == expected


### PR DESCRIPTION
Similar to https://github.com/NillionNetwork/nilvm/pull/104 this adds context supports in selectors via `$.<variable>` syntax.