### PR TITLE
feat: dependency and read the docs updates

### DIFF
--- a/.github/workflows/build-publish-sign-release.yml
+++ b/.github/workflows/build-publish-sign-release.yml
@@ -14,9 +14,9 @@ jobs:
       - call-workflow-lint-test-cover-docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Python.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
           architecture: x64
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all the package distributions.
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: python-package-distributions
           path: dist/
@@ -58,12 +58,12 @@ jobs:
       id-token: write # For Sigstore.
     steps:
       - name: Download all the package distributions.
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: python-package-distributions
           path: dist/
       - name: Sign the package distributions with Sigstore.
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.0.1
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/lint-test-cover-docs.yml
+++ b/.github/workflows/lint-test-cover-docs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/lint-test-cover-docs.yml
+++ b/.github/workflows/lint-test-cover-docs.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -36,7 +36,7 @@ jobs:
         run: |
           uv sync --extra coveralls
           uv run coveralls --service=github # Submit to coveralls.
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.12'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.pylintrc
+++ b/.pylintrc
@@ -59,10 +59,11 @@ ignore-paths=
 # Emacs file locks
 ignore-patterns=^\.#
 
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
-# supports qualified module names, as well as Unix pattern matching.
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
 ignored-modules=
 
 # Python code to execute, usually for sys.path manipulation such as
@@ -86,9 +87,13 @@ load-plugins=
 # Pickle collected data for later comparisons.
 persistent=yes
 
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.12
 
 # Discover python modules and packages in the file system subtree.
 recursive=no
@@ -302,6 +307,9 @@ max-locals=30
 # Maximum number of parents for a class (see R0901).
 max-parents=7
 
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=10
+
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 
@@ -429,14 +437,15 @@ disable=raw-checker-failed,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-        unnecessary-lambda-assignment,
-        redundant-unittest-assert
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero,
+        using-generic-type-syntax-in-unsupported-version
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
+enable=
 
 
 [METHOD_ARGS]
@@ -468,6 +477,11 @@ max-nested-blocks=5
 # printed.
 never-returning-functions=sys.exit,argparse.parse_error
 
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
 
 [REPORTS]
 
@@ -482,9 +496,10 @@ evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor 
 # used to format the message information. See doc for all details.
 msg-template=
 
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
-# mypackage.mymodule.MyReporterClass.
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
 #output-format=
 
 # Tells whether to display a full report or only the messages.
@@ -518,7 +533,7 @@ min-similarity-lines=4
 max-spelling-suggestions=4
 
 # Spelling dictionary name. No available dictionaries : You need to install
-# both the python package and the system dependency for enchant to work..
+# both the python package and the system dependency for enchant to work.
 spelling-dict=
 
 # List of comma separated words that should be considered directives if they
@@ -586,7 +601,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
 # of finding the hint is based on edit distance.
 missing-member-hint=yes
 
-# The minimum edit distance a name should have in order to be considered a
+# The maximum edit distance a name should have in order to be considered a
 # similar match for a missing member name.
 missing-member-hint-distance=1
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,14 +6,10 @@ sphinx:
 formats:
   - pdf
 
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
 build:
   os: 'ubuntu-22.04'
   tools:
     python: '3.12'
+  jobs:
+    install:
+      - python -m pip install --no-cache-dir --use-pep517 .[docs]

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,4 +18,5 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	rm _source/modules.rst
+	rm _source/nuc.rst
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,6 @@ html_theme = "sphinx_rtd_theme"
 
 # Theme options for Read the Docs.
 html_theme_options = {
-    "display_version": True,
     "collapse_navigation": True,
     "navigation_depth": 1,
     "titles_only": True,

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -13,6 +13,7 @@ set BUILDDIR=_build
 if "%1" == "" goto help
 
 del _source\modules.rst
+del _source\nuc.rst
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nuc"
-version = "0.2.0"
+version = "0.3.0"
 description = """\
     Data structures and functionalities for the Nillion \
     Network user identity and authorization framework.\
@@ -21,17 +21,17 @@ Documentation = "https://nuc.readthedocs.io"
 [project.optional-dependencies]
 docs = [
     "toml~=0.10.2",
-    "sphinx~=7.1",
-    "sphinx-rtd-theme~=2.0.0",
+    "sphinx~=8.0",
+    "sphinx-rtd-theme~=3.0",
     "myst-parser==2.0.0"
 ]
 test = [
-    "pytest~=8.2",
-    "pytest-cov~=5.0"
+    "pytest~=8.4",
+    "pytest-cov~=7.0"
 ]
 lint = [
     "ruff==0.7.0", 
-    "pylint~=3.2.0",
+    "pylint~=3.3.0",
     "pyright==1.1.396",
 ]
 coveralls = [
@@ -44,7 +44,7 @@ publish = [
 
 [build-system]
 requires = [
-    "setuptools>=68.0"
+    "setuptools>=77.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ description = """\
     Data structures and functionalities for the Nillion \
     Network user identity and authorization framework.\
     """
-license = {text = "MIT"}
+license = "MIT"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 dependencies = [
     "cosmpy==0.9.2",
     "requests==2.32.3",
-    "secp256k1==0.14.0",
+    "secp256k1==0.14.0"
 ]
 
 [project.urls]
@@ -21,9 +21,9 @@ Documentation = "https://nuc.readthedocs.io"
 [project.optional-dependencies]
 docs = [
     "toml~=0.10.2",
-    "sphinx~=8.0",
+    "sphinx~=7.4",
     "sphinx-rtd-theme~=3.0",
-    "myst-parser==2.0.0"
+    "myst-parser==3.0.0"
 ]
 test = [
     "pytest~=8.4",
@@ -32,7 +32,7 @@ test = [
 lint = [
     "ruff==0.7.0", 
     "pylint~=3.3.0",
-    "pyright==1.1.396",
+    "pyright==1.1.396"
 ]
 coveralls = [
     "coveralls~=4.0"


### PR DESCRIPTION
Bumps dependency version locks, GitHub Actions versions, and linting rules; adds Python 3.13 tests and [Read the Docs support](https://nuc.readthedocs.io/en/feat-dependency-and-read-the-docs-updates/).

The support for Read the Docs may require repair shortly because it was fixed using the flag suggested below:
```
  | Requirements should be satisfied by a PEP 517 installer.
  | If you are using pip, you can try `pip install --use-pep517`.
  |  
  | By 2025-Oct-31, you need to update your project and remove deprecated calls
  | or your builds will no longer be supported.
```
Ultimately, the possibility of secp256k1 building in up-to-date environments will erode over time and we may need to fork our own version so we can publish our own updated wheel files for various platforms.